### PR TITLE
made file-extension case insensitive at delivering as webp

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ Add a map directive in your global nginx configuration:
 
 and add these rules to your `server` configuration:
 
-    location ~* ^/fileadmin/.+\.(png|jpg|jpeg)$ {
+    location ~* ^/fileadmin/.+\.(?i)(png|jpe?g)$ {
             add_header Vary Accept;
             try_files $uri$webp_suffix $uri =404;
     }
-    location ~* ^/other-storage/.+\.(png|jpg|jpeg)$ {
+    location ~* ^/other-storage/.+\.(?i)(png|jpe?g)$ {
             add_header Vary Accept;
             try_files $uri$webp_suffix $uri =404;
     }
@@ -113,8 +113,8 @@ Make sure that there are no other rules that already apply to the specified imag
         RewriteEngine On
         RewriteCond %{HTTP_ACCEPT} image/webp
         RewriteCond %{DOCUMENT_ROOT}/$1.$2.webp -f
-        RewriteRule ^(fileadmin/.+)\.(png|jpg|jpeg)$ $1.$2.webp [T=image/webp,E=accept:1]
-        RewriteRule ^(other-storage/.+)\.(png|jpg|jpeg)$ $1.$2.webp [T=image/webp,E=accept:1]
+        RewriteRule ^(fileadmin/.+)\.(?i)(png|jpe?g)$ $1.$2.webp [T=image/webp,E=accept:1]
+        RewriteRule ^(other-storage/.+)\.(?i)(png|jpe?g)$ $1.$2.webp [T=image/webp,E=accept:1]
     </IfModule>
 
     <IfModule mod_headers.c>


### PR DESCRIPTION
1. Added (?i) befor the extension check as .JPG images would be ignored. (not by generating the webp-files but in delivering them!) (https://www.regular-expressions.info/modifiers.html)
2. transformed extension check from (png|jpg|jpeg) to (png|jpe?g), same but shorter and valid Regex!

Tested with Apache and working fine, did not test with Nginx but as same changes it should work.

NOTE: without the (?i):
1. image.JPG will not getting delivered as webp as it is not matching the pattern!
2. image.jpg will be delivered as webp. I tested this with version 2.1.0